### PR TITLE
Hide caption when done editing

### DIFF
--- a/DIImageView/DIImageView.swift
+++ b/DIImageView/DIImageView.swift
@@ -89,10 +89,13 @@ class DIImageView: UIImageView, UITextFieldDelegate {
         return (textSize.width + 16 < textField.bounds.size.width)
     }
     
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard caption == textField else { return }
+        caption.isHidden = caption.text?.isEmpty ?? true
+    }
+    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         guard caption == textField else { return true }
-        caption.resignFirstResponder()
-        caption.isHidden = caption.text?.isEmpty ?? true
         return caption.resignFirstResponder()
     }
     


### PR DESCRIPTION
The caption can lose first responder if another text field is tapped, so we should handle hiding the caption when we are done editing, rather than when the user hits return.

Also this change removed the extra call to caption.resignFirstResponder().